### PR TITLE
newlib: Add uksignal dependency

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -11,6 +11,7 @@ menuconfig LIBNEWLIBC
 	select LIBUKALLOC
 	select LIBUKTIME
 	select LIBVFSCORE
+	select LIBUKSIGNAL
 	select LIBPOSIX_PROCESS
 	select LIBPOSIX_USER
 	select FPSIMD if ARCH_ARM_64


### PR DESCRIPTION
Add uksignal as a dependency to newlib

Signed-off-by: Sharan Santhanam <sharan.santhanam@neclab.eu>
