### PR TITLE
signal: Add killpg to header

### DIFF
--- a/musl-imported/include/signal.h
+++ b/musl-imported/include/signal.h
@@ -104,6 +104,7 @@ int sigsuspend(const sigset_t *mask);
 int sigwait(const sigset_t *set, int *sig);
 
 int kill(pid_t pid, int sig);
+int killpg(int pgrp, int sig);
 int raise(int sig);
 
 typedef void (*sighandler_t)(int);


### PR DESCRIPTION
Extend signal.h to include killpg

Signed-off-by: Sharan Santhanam <sharan.santhanam@neclab.eu>
