### PR TITLE
include/syscall.h: add cpp macros

### DIFF
--- a/include/sys/syscall.h
+++ b/include/sys/syscall.h
@@ -35,7 +35,15 @@
 
 #include <uk/config.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 long syscall(long num, ...);
+
+#ifdef __cplusplus
+}
+#endif
 
 #if CONFIG_LIBSYSCALL_SHIM
 /* Provide SYS_syscallname and __NR_syscallname variants */


### PR DESCRIPTION
Make the syscall header compatible with C++ compiler.

Signed-off-by: Daniel Dinca <dincadaniel97@gmail.com>