### PR TITLE
Add SHA256 checksum

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -52,6 +52,8 @@ $(eval $(call addlib_s,libnewlibglue,$(CONFIG_LIBNEWLIBC)))
 LIBNEWLIB_VERSION=2.5.0.20170922
 LIBNEWLIB_URL=http://sourceware.org/pub/newlib/newlib-$(LIBNEWLIB_VERSION).tar.gz
 LIBNEWLIB_PATCHDIR=$(LIBNEWLIBC_BASE)/patches
+LIBNEWLIBC_ORIGIN_SHA256=16ccacbb9155b89a8333da057bfd2952d334795a38dfffcef6a4d83ae12e7275
+
 $(eval $(call fetch,libnewlibc,$(LIBNEWLIB_URL)))
 $(eval $(call patch,libnewlibc,$(LIBNEWLIB_PATCHDIR),newlib-$(LIBNEWLIB_VERSION)))
 


### PR DESCRIPTION
We add the SHA256 checksum of the downloaded archive so that Unikraft's build system is able to do an integrity check of the download.
This commit can be applied even without integrating [Unikraft PR 181](https://github.com/unikraft/unikraft/pull/181) because it wouldn't have any effect in such a case.