### PR TITLE
Remove implementation of time()

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -849,7 +849,6 @@ LIBNEWLIBC_SRCS-y += $(LIBNEWLIB_LIBC)/time/mktime.c
 LIBNEWLIBC_SRCS-y += $(LIBNEWLIB_LIBC)/time/month_lengths.c
 LIBNEWLIBC_SRCS-y += $(LIBNEWLIB_LIBC)/time/strftime.c
 LIBNEWLIBC_SRCS-y += $(LIBNEWLIB_LIBC)/time/strptime.c
-LIBNEWLIBC_SRCS-y += $(LIBNEWLIB_LIBC)/time/time.c
 LIBNEWLIBC_SRCS-y += $(LIBNEWLIB_LIBC)/time/tzcalc_limits.c
 LIBNEWLIBC_SRCS-y += $(LIBNEWLIB_LIBC)/time/tzlock.c
 LIBNEWLIBC_SRCS-y += $(LIBNEWLIB_LIBC)/time/tzset.c


### PR DESCRIPTION
`time()` is now implemented as part of `uktime` Unikraft library. Remove newlib implementation of `time()` to have a single definition.