### PR TITLE
Check if MIN and MAX definitions are defined  somewhere else.

### DIFF
--- a/patches/0012-newlib-include-sys-Fix-MAX-and-MIN-redefinition.patch
+++ b/patches/0012-newlib-include-sys-Fix-MAX-and-MIN-redefinition.patch
@@ -1,0 +1,30 @@
+From fcb74ab953ddaf786bec94c6fa1ab339e8d2d691 Mon Sep 17 00:00:00 2001
+From: Gabriel Mocanu <gabi.mocanu98@gmail.com>
+Date: Sat, 20 Nov 2021 11:10:12 +0200
+Subject: [PATCH 2/2] newlib/include/sys: Fix MAX and MIN redefinition
+
+Signed-off-by: Gabriel Mocanu <gabi.mocanu98@gmail.com>
+---
+ newlib/libc/include/sys/param.h | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/newlib/libc/include/sys/param.h b/newlib/libc/include/sys/param.h
+index 9a6f115..093f028 100644
+--- a/newlib/libc/include/sys/param.h
++++ b/newlib/libc/include/sys/param.h
+@@ -25,8 +25,12 @@
+ 
+ #define MAXPATHLEN PATH_MAX
+ 
++#ifndef MAX
+ #define MAX(a,b) ((a) > (b) ? (a) : (b))
++#endif
++#ifndef MIN
+ #define MIN(a,b) ((a) < (b) ? (a) : (b))
++#endif
+ 
+ #ifndef howmany
+ #define    howmany(x, y)   (((x)+((y)-1))/(y))
+-- 
+2.27.0
+


### PR DESCRIPTION
This PR resolves some warnings about redefining the MIN and MAX macros that I discovered while trying to compile the micropython application.

![Screenshot from 2021-11-27 09-57-40](https://user-images.githubusercontent.com/34304856/143673359-18e02854-f5a6-423c-b091-ec67a5f9bb43.png)

I think that this should go after #13 .



Signed-off-by: Gabriel Mocanu <gabi.mocanu98@gmail.com>