### PR TITLE
lib-newlib: Update sigset_t structure to 1024 bits just as in musl

### DIFF
--- a/musl-imported/include/signal.h
+++ b/musl-imported/include/signal.h
@@ -60,7 +60,10 @@ extern "C" {
 
 typedef int pid_t;
 typedef int sig_atomic_t;
-typedef unsigned long __sigset_t;
+#ifndef _SYS__SIGSET_H_
+#define _SYS__SIGSET_H_
+typedef struct { unsigned long __bits[128/sizeof(long)]; } __sigset_t;
+#endif /* !_SYS__SIGSET_H_ */
 typedef __sigset_t sigset_t;
 
 #define NSIG _NSIG

--- a/patches/0013-Change-sigset_t-to-be-compatible-with-uk_signal-whic.patch
+++ b/patches/0013-Change-sigset_t-to-be-compatible-with-uk_signal-whic.patch
@@ -1,0 +1,26 @@
+From cd56be1871262f6f56a2e0fb78a585da82a5d5e6 Mon Sep 17 00:00:00 2001
+From: Dragos Iulian Argint <dragosargint21@gmail.com>
+Date: Sun, 20 Feb 2022 00:30:10 +0200
+Subject: [PATCH] Change sigset_t to be compatible with uk_signal which uses
+ musl's type (i.e. sigset_t is no longer an unsigned long)
+
+Signed-off-by: Dragos Iulian Argint <dragosargint21@gmail.com>
+---
+ _sigset.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/newlib/libc/include/sys/_sigset.h b/newlib/libc/include/sys/_sigset.h
+index a9c0d2d..794381f 100644
+--- a/newlib/libc/include/sys/_sigset.h
++++ b/newlib/libc/include/sys/_sigset.h
+@@ -38,6 +38,6 @@
+ #ifndef _SYS__SIGSET_H_
+ #define	_SYS__SIGSET_H_
+ 
+-typedef unsigned long __sigset_t;
++typedef struct { unsigned long __bits[128/sizeof(long)]; } __sigset_t;
+ 
+ #endif /* !_SYS__SIGSET_H_ */
+-- 
+2.17.1
+


### PR DESCRIPTION
This PR changes the sigset_t structure from newlib to 1024 bits to solve conflicts that occur between musl and newlib when linked with uk_signal. Musl uses a 1024-bit mask, and newlib uses a 64-bit mask (i.e. an unsigned long).

This PR is part of a group that aims to solve compiling errors for both musl and newlib:
* https://github.com/unikraft/lib-newlib/pull/15
* https://github.com/unikraft/lib-musl/pull/4
* https://github.com/unikraft/unikraft/pull/327
* https://github.com/unikraft/unikraft/pull/326