### PR TITLE
Remove mprotect stub

### DIFF
--- a/mem.c
+++ b/mem.c
@@ -65,8 +65,3 @@ void free(void *ptr)
 {
 	return uk_free(uk_alloc_get_default(), ptr);
 }
-
-int mprotect(void *addr __unused, size_t len __unused, int prot __unused)
-{
-	return 0;
-}


### PR DESCRIPTION
This commit removes the stub for mprotect as it has been introduced as stubbed system call in ukmmap. This PR is necessary to allow building lib-newlib against the latest unikraft core repo that includes commit da407a37.