### PR TITLE
Fix warning due to the 'utime' function not being declared in newlib.

### DIFF
--- a/include/utime.h
+++ b/include/utime.h
@@ -1,0 +1,13 @@
+#ifndef NEWLIBGLUE_UTIME_H
+#define NEWLIBGLUE_UTIME_H
+
+#include <sys/types.h>
+
+struct utimbuf {
+	time_t actime;
+	time_t modtime;
+};
+
+int utime(const char *path, const struct utimbuf *times);
+
+#endif /* NEWLIBGLUE_TIME_H */


### PR DESCRIPTION
This PR is part of the Unikraft Lyon Hackathon.

This warning occured while building [app-sqlite](https://github.com/unikraft/app-sqlite) :

```
/home/ubuntu/challenges/sqlite-warnings/apps/app-sqlite/build/libsqlite/origin/sqlite-amalgamation-3300100/sqlite3.c: In function ‘dotlockLock’:
/home/ubuntu/challenges/sqlite-warnings/apps/app-sqlite/build/libsqlite/origin/sqlite-amalgamation-3300100/sqlite3.c:34975:5: warning: implicit declaration of function ‘utime’; did you mean ‘utimes’? [-Wimplicit-function-declaration]
34975 |     utime(zLockFile, NULL);
      |     ^~~~~
      |     utimes
```

This is apparently due to the fact that [lib-sqlite](https://github.com/unikraft/lib-sqlite) relies on lib-newlib and not on nolibc, and the `utime` function is not declared correctly in newlib, even though lib-sqlite clearly defines the `HAVE_UTIME` macro.