### PR TITLE
include: Fix macros in order to facilitate running apps on `AArch64`

### DIFF
--- a/include/fcntl.h
+++ b/include/fcntl.h
@@ -15,10 +15,8 @@
 #define O_DIRECT     040000
 #define O_NOATIME  01000000
 #elif ((defined CONFIG_ARCH_ARM_64) || (defined CONFIG_ARCH_ARM_32))
-#undef O_NONBLOCK
-#define O_NONBLOCK    04000
 #define O_NOFOLLOW  0100000
-#define O_DIRECTORY  040000
+#define O_DIRECTORY 0400000000
 #define O_CLOEXEC  02000000
 #define O_DSYNC      010000
 #define O_ASYNC      020000

--- a/include/limits.h
+++ b/include/limits.h
@@ -51,7 +51,7 @@
 #define SHRT_MAX        0x7fff
 #define USHRT_MAX       0xffff
 
-#if defined(__x86_64__)
+#if defined(__x86_64__) || defined(__ARM_64__)
 # define LONG_MAX       0x7fffffffffffffffL
 # define ULONG_MAX      0xffffffffffffffffUL
 #else


### PR DESCRIPTION
This PR fixes multiple issues regarding `newlib` support on `AArch64`.

Signed-off-by: Maria Sfiraiala <maria.sfiraiala@gmail.com>
Signed-off-by: Eduard Vintilă <eduard.vintila47@gmail.com>