### PR TITLE
Remove inclusion of uk/user.h

### DIFF
--- a/include/sys/unistd.h
+++ b/include/sys/unistd.h
@@ -36,7 +36,16 @@
 /* Use newlib definitions */
 #include_next <sys/unistd.h>
 
-/* Use Unikraft user related definitions */
-#include <uk/user.h>
+#ifdef _GNU_SOURCE
+#define __NEED_uid_t
+#define __NEED_gid_t
+#include <sys/types.h>
+
+int getresuid(uid_t *ruid, uid_t *euid, uid_t *suid);
+int setresuid(uid_t ruid, uid_t euid, uid_t suid);
+
+int getresgid(gid_t *rgid, gid_t *egid, gid_t *sgid);
+int setresgid(gid_t rgid, gid_t egid, gid_t sgid);
+#endif /* _GNU_SOURCE */
 
 #endif /* __NEWLIB_GLUE__SYS_UNISTD_H__ */


### PR DESCRIPTION
Currently, we include uk/user.h from the core's posix-user library to declare signatures for get/setresuid and get/setresgid. However, these definitions should be part of the C library and not Unikraft. This commit removes the dependency on the uk/user.h header and moves the function declaration into the unistd.h directly. It also adds the missing _GNU_SOURCE guard.

This PR is a prerequisite for https://github.com/unikraft/unikraft/pull/504