### PR TITLE
[WIP] Version bump to 4.0.0

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -47,10 +47,10 @@ $(eval $(call addlib_s,libnewlibglue,$(CONFIG_LIBNEWLIBC)))
 ################################################################################
 # Sources
 ################################################################################
-LIBNEWLIB_VERSION=2.5.0.20170922
+LIBNEWLIB_VERSION=4.0.0
 LIBNEWLIB_URL=http://sourceware.org/pub/newlib/newlib-$(LIBNEWLIB_VERSION).tar.gz
 LIBNEWLIB_PATCHDIR=$(LIBNEWLIBC_BASE)/patches
-LIBNEWLIBC_ORIGIN_SHA256=16ccacbb9155b89a8333da057bfd2952d334795a38dfffcef6a4d83ae12e7275
+LIBNEWLIBC_ORIGIN_SHA256=71ffb00979ce978216debb2b037dc8b1b3d780ebc2e0fa0e2757188704291052
 
 $(eval $(call fetch,libnewlibc,$(LIBNEWLIB_URL)))
 $(eval $(call patch,libnewlibc,$(LIBNEWLIB_PATCHDIR),newlib-$(LIBNEWLIB_VERSION)))

--- a/patches/0003-sys-stat.h-provide-st_-a-c-m-tim.patch
+++ b/patches/0003-sys-stat.h-provide-st_-a-c-m-tim.patch
@@ -1,48 +1,26 @@
-From ec3f6adeefbd5f707e84eee74c0da1f691bad4eb Mon Sep 17 00:00:00 2001
-From: Florian Schmidt <florian.schmidt@neclab.eu>
-Date: Wed, 17 Apr 2019 15:05:20 +0200
-Subject: [PATCH] sys/stat.h: provide st_{a,c,m}tim;
-
-Signed-off-by: Florian Schmidt <florian.schmidt@neclab.eu>
----
- newlib/libc/include/sys/stat.h | 21 ---------------------
- 1 file changed, 21 deletions(-)
-
-diff --git a/newlib/libc/include/sys/stat.h b/newlib/libc/include/sys/stat.h
-index eee98db64..0d2b9c9de 100644
---- a/newlib/libc/include/sys/stat.h
-+++ b/newlib/libc/include/sys/stat.h
-@@ -34,37 +34,16 @@ struct	stat
-   gid_t		st_gid;
-   dev_t		st_rdev;
-   off_t		st_size;
--#if defined(__rtems__)
+--- a/newlib/libc/include/sys/stat.h    2022-10-23 15:34:20.636665821 +0200
++++ b/newlib/libc/include/sys/stat.h    2022-10-23 16:29:26.606666652 +0200
+@@ -34,27 +34,16 @@
+   gid_t                st_gid;
+   dev_t                st_rdev;
+   off_t                st_size;
+-#if defined(__svr4__) && !defined(__PPC__) && !defined(__sun__)
+-  time_t       st_atime;
+-  time_t       st_mtime;
+-  time_t       st_ctime;
+-#else
    struct timespec st_atim;
    struct timespec st_mtim;
    struct timespec st_ctim;
    blksize_t     st_blksize;
-   blkcnt_t	st_blocks;
--#else
--  /* SysV/sco doesn't have the rest... But Solaris, eabi does.  */
--#if defined(__svr4__) && !defined(__PPC__) && !defined(__sun__)
--  time_t	st_atime;
--  time_t	st_mtime;
--  time_t	st_ctime;
--#else
--  time_t	st_atime;
--  long		st_spare1;
--  time_t	st_mtime;
--  long		st_spare2;
--  time_t	st_ctime;
--  long		st_spare3;
--  blksize_t	st_blksize;
--  blkcnt_t	st_blocks;
--  long	st_spare4[2];
+   blkcnt_t     st_blocks;
+-#if !defined(__rtems__)
+-  long         st_spare4[2];
 -#endif
 -#endif
  };
  
--#if defined(__rtems__)
+-#if !(defined(__svr4__) && !defined(__PPC__) && !defined(__sun__)) && !defined(__cris__)
  #define st_atime st_atim.tv_sec
  #define st_ctime st_ctim.tv_sec
  #define st_mtime st_mtim.tv_sec
@@ -50,6 +28,3 @@ index eee98db64..0d2b9c9de 100644
  
  #endif
  
--- 
-2.21.0
-

--- a/patches/0004-Fix-setgroups-declaration.patch
+++ b/patches/0004-Fix-setgroups-declaration.patch
@@ -14,15 +14,15 @@ diff --git a/newlib/libc/include/sys/unistd.h b/newlib/libc/include/sys/unistd.h
 index 75f8a51..bcb2f69 100644
 --- a/newlib/libc/include/sys/unistd.h
 +++ b/newlib/libc/include/sys/unistd.h
-@@ -188,7 +188,7 @@ int     _EXFUN(seteuid, (uid_t __uid ));
- int     _EXFUN(setgid, (gid_t __gid ));
+@@ -206,7 +206,7 @@
+ int     setgid (gid_t __gid);
  #endif
  #if __BSD_VISIBLE
--int	_EXFUN(setgroups, (int ngroups, const gid_t *grouplist ));
-+int	_EXFUN(setgroups, (size_t ngroups, const gid_t *grouplist ));
+-int    setgroups (int ngroups, const gid_t *grouplist);
++int    setgroups (size_t ngroups, const gid_t *grouplist);
  #endif
  #if __BSD_VISIBLE || (__XSI_VISIBLE && __XSI_VISIBLE < 500)
- int	_EXFUN(sethostname, (const char *, size_t));
+ int    sethostname (const char *, size_t);
 -- 
 2.11.0
 

--- a/patches/0005-sys-stat.h-fix-lstat_mknod-declaration.patch
+++ b/patches/0005-sys-stat.h-fix-lstat_mknod-declaration.patch
@@ -1,26 +1,11 @@
-From 272e94f69597a1f4c789b345976c293ca63f70c5 Mon Sep 17 00:00:00 2001
-From: Gaulthier Gain <gaulthier.gain@uliege.be>
-Date: Mon, 5 Aug 2019 08:27:22 +0000
-Subject: [PATCH] expose lstat/mknod declaration
-
-Signed-off-by: Gaulthier Gain <gaulthier.gain@uliege.be>
----
- newlib/libc/include/sys/stat.h | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
-
-diff --git a/newlib/libc/include/sys/stat.h b/newlib/libc/include/sys/stat.h
-index a09f2f0..f2a663a 100644
 --- a/newlib/libc/include/sys/stat.h
 +++ b/newlib/libc/include/sys/stat.h
-@@ -132,7 +132,7 @@ int _EXFUN(lstat,( const char *__restrict __path, struct stat *__restrict __sbuf
- int	_EXFUN(stat,( const char *__restrict __path, struct stat *__restrict __sbuf ));
- mode_t	_EXFUN(umask,( mode_t __mask ));
+@@ -142,7 +142,7 @@
+ int    stat (const char *__restrict __path, struct stat *__restrict __sbuf );
+ mode_t umask (mode_t __mask );
  
 -#if defined (__SPU__) || defined(__rtems__) || defined(__CYGWIN__) && !defined(__INSIDE_CYGWIN__)
 +#if defined (__SPU__) || defined(__rtems__) || defined(__Unikraft__) || defined(__CYGWIN__) && !defined(__INSIDE_CYGWIN__)
- int	_EXFUN(lstat,( const char *__restrict __path, struct stat *__restrict __buf ));
- int	_EXFUN(mknod,( const char *__path, mode_t __mode, dev_t __dev ));
+ int    lstat (const char *__restrict __path, struct stat *__restrict __buf );
+ int    mknod (const char *__path, mode_t __mode, dev_t __dev );
  #endif
--- 
-2.17.1
-

--- a/patches/0006-Add-si_addr-field-for-siginfo_t-and-use-__rtems__-de.patch
+++ b/patches/0006-Add-si_addr-field-for-siginfo_t-and-use-__rtems__-de.patch
@@ -1,19 +1,6 @@
-From 7d668a38739f734ed1edc6aab925baf9f19f5ca4 Mon Sep 17 00:00:00 2001
-From: Costin Lupu <costin.lup@gmail.com>
-Date: Fri, 16 Aug 2019 20:19:14 +0200
-Subject: [PATCH] Add si_addr field for siginfo_t and use __rtems__
- declarations
-
-Signed-off-by: Costin Lupu <costin.lupu@cs.pub.ro>
----
- newlib/libc/include/sys/signal.h | 19 ++++++++++++++++++-
- 1 file changed, 18 insertions(+), 1 deletion(-)
-
-diff --git a/newlib/libc/include/sys/signal.h b/newlib/libc/include/sys/signal.h
-index ab35718..f87ed6c 100644
---- a/newlib/libc/include/sys/signal.h
-+++ b/newlib/libc/include/sys/signal.h
-@@ -69,10 +69,27 @@ typedef struct {
+--- a/newlib/libc/include/sys/signal.h  2022-10-23 15:34:20.636665821 +0200
++++ b/newlib/libc/include/sys/signal.h  2022-10-23 17:01:45.073247954 +0200
+@@ -69,10 +69,27 @@
    int          si_signo;    /* Signal number */
    int          si_code;     /* Cause of the signal */
    union sigval si_value;    /* Signal value */
@@ -41,7 +28,3 @@ index ab35718..f87ed6c 100644
 +#if defined(__rtems__) || defined(__Unikraft__)
  
  /*  3.3.8 Synchronously Accept a Signal, P1003.1b-1993, p. 76 */
- 
--- 
-2.20.1
-

--- a/patches/0008-Apply-hackish-patch-in-order-to-include-custom-mallo.patch
+++ b/patches/0008-Apply-hackish-patch-in-order-to-include-custom-mallo.patch
@@ -1,26 +1,12 @@
-From 5671ec3aeb7f237e0c5d25f13a7f2004756b6eea Mon Sep 17 00:00:00 2001
-From: Costin Lupu <costin.lup@gmail.com>
-Date: Fri, 16 Aug 2019 23:09:15 +0200
-Subject: [PATCH] Apply hackish patch in order to include custom malloc.h
- header first
-
-Signed-off-by: Costin Lupu <costin.lupu@cs.pub.ro>
----
- newlib/libc/include/malloc.h | 3 +++
- 1 file changed, 3 insertions(+)
-
-diff --git a/newlib/libc/include/malloc.h b/newlib/libc/include/malloc.h
-index 41b5efd..682dde4 100644
 --- a/newlib/libc/include/malloc.h
 +++ b/newlib/libc/include/malloc.h
-@@ -166,4 +166,7 @@ extern void cfree _PARAMS ((_PTR));
- }
- #endif
+@@ -166,6 +166,9 @@
+ extern void cfree (void *);
+ #endif /* __CYGWIN__ */
  
 +#else
 +#include_next <malloc.h>
 +
- #endif /* _INCLUDE_MALLOC_H_ */
--- 
-2.20.1
-
+ #ifdef __cplusplus
+ }
+ #endif

--- a/patches/0009-stdatomic.h-Fix-atomic_-definitions.patch
+++ b/patches/0009-stdatomic.h-Fix-atomic_-definitions.patch
@@ -1,93 +1,63 @@
-From 2886f7e1f6546ef85778589cdfe65b8d0fb99002 Mon Sep 17 00:00:00 2001
-From: Vlad-Andrei Badoiu <vlad_andrei.badoiu@stud.acs.upb.ro>
-Date: Tue, 17 Dec 2019 18:50:03 +0200
-Subject: [PATCH 1/1] stdatomic.h: Fix atomic_* definitions
-
-The current atomic_* do not compile under GCC, we adapt the
-implementation to follow the existing ones from gcc.
-
-Signed-off-by: Vlad-Andrei Badoiu <vlad_andrei.badoiu@stud.acs.upb.ro>
----
- newlib/libc/include/stdatomic.h | 58 ++++++++++++++++++++++++---------
- 1 file changed, 42 insertions(+), 16 deletions(-)
-
-diff --git a/newlib/libc/include/stdatomic.h b/newlib/libc/include/stdatomic.h
-index 09c0cf7..daa1969 100644
---- a/newlib/libc/include/stdatomic.h
-+++ b/newlib/libc/include/stdatomic.h
-@@ -258,30 +258,56 @@ typedef _Atomic(uintmax_t)		atomic_uintmax_t;
- #define	atomic_store_explicit(object, desired, order)			\
- 	__c11_atomic_store(object, desired, order)
+--- a/newlib/libc/include/stdatomic.h   2022-10-23 15:34:20.636665821 +0200
++++ b/newlib/libc/include/stdatomic.h   2022-10-23 17:10:46.556581219 +0200
+@@ -255,14 +255,28 @@
+ #define        atomic_store_explicit(object, desired, order)             \
+        __c11_atomic_store(object, desired, order)
  #elif defined(__GNUC_ATOMICS)
--#define	atomic_compare_exchange_strong_explicit(object, expected,	\
--    desired, success, failure)						\
--	__atomic_compare_exchange_n(&(object)->__val, expected,		\
--	    desired, 0, success, failure)
--#define	atomic_compare_exchange_weak_explicit(object, expected,		\
--    desired, success, failure)						\
--	__atomic_compare_exchange_n(&(object)->__val, expected,		\
--	    desired, 1, success, failure)
-+#define	atomic_compare_exchange_strong_explicit(object, expected,			\
-+    desired, success, failure)								\
-+__extension__										\
-+({											\
-+	__auto_type __atomic_compare_exchange_ptr = (object);				\
-+	__typeof__ (*__atomic_compare_exchange_ptr) __atomic_compare_exchange_tmp 	\
-+	= (desired);									\
-+	__atomic_compare_exchange (__atomic_compare_exchange_ptr, (expected),		\
-+		&__atomic_compare_exchange_tmp,						\
-+		0, (success), (failure));						\
+-#define        atomic_compare_exchange_strong_explicit(object, expected, \
+-    desired, success, failure)                                         \
+-       __atomic_compare_exchange_n(object, expected,                   \
+-           desired, 0, success, failure)
+-#define        atomic_compare_exchange_weak_explicit(object, expected,   \
+-    desired, success, failure)                                         \
+-       __atomic_compare_exchange_n(object, expected,                   \
+-           desired, 1, success, failure)
++#define        atomic_compare_exchange_strong_explicit(object, expected, \
++    desired, success, failure)                                           \
++__extension__                                                            \
++({                                                                       \
++       __auto_type __atomic_compare_exchange_ptr = (object);             \
++       __typeof__ (*__atomic_compare_exchange_ptr) __atomic_compare_exchange_tmp  \
++       = (desired);                                                      \
++       __atomic_compare_exchange (__atomic_compare_exchange_ptr, (expected),              \
++               &__atomic_compare_exchange_tmp,                           \
++               0, (success), (failure));                                 \
 +  })
-+#define	atomic_compare_exchange_weak_explicit(object, expected,				\
-+    desired, success, failure)								\
-+__extension__										\
-+({											\
-+	__auto_type __atomic_compare_exchange_ptr = (object);				\
-+	__typeof__ (*__atomic_compare_exchange_ptr) __atomic_compare_exchange_tmp 	\
-+	= (desired);									\
-+	__atomic_compare_exchange (__atomic_compare_exchange_ptr, (expected),		\
-+		&__atomic_compare_exchange_tmp,						\
-+		1, (success), (failure));						\
++#define        atomic_compare_exchange_weak_explicit(object, expected,   \
++    desired, success, failure)                                           \
++__extension__                                                            \
++({                                                                       \
++       __auto_type __atomic_compare_exchange_ptr = (object);             \
++       __typeof__ (*__atomic_compare_exchange_ptr) __atomic_compare_exchange_tmp  \
++       = (desired);                                                      \
++       __atomic_compare_exchange (__atomic_compare_exchange_ptr, (expected),              \
++               &__atomic_compare_exchange_tmp,                           \
++               1, (success), (failure));                                 \
 +  })
- #define	atomic_exchange_explicit(object, desired, order)		\
--	__atomic_exchange_n(&(object)->__val, desired, order)
-+	__atomic_exchange_n((object), (desired), (order))
- #define	atomic_fetch_add_explicit(object, operand, order)		\
--	__atomic_fetch_add(&(object)->__val, operand, order)
-+	__atomic_fetch_add((object), (operand), (order))
- #define	atomic_fetch_and_explicit(object, operand, order)		\
--	__atomic_fetch_and(&(object)->__val, operand, order)
-+	__atomic_fetch_and((object), (operand), (order))
- #define	atomic_fetch_or_explicit(object, operand, order)		\
--	__atomic_fetch_or(&(object)->__val, operand, order)
-+	__atomic_fetch_or((object), (operand), (order))
- #define	atomic_fetch_sub_explicit(object, operand, order)		\
--	__atomic_fetch_sub(&(object)->__val, operand, order)
-+	__atomic_fetch_sub((object), (operand), (order))
- #define	atomic_fetch_xor_explicit(object, operand, order)		\
--	__atomic_fetch_xor(&(object)->__val, operand, order)
-+	__atomic_fetch_xor((object), (operand), (order))
- #define	atomic_load_explicit(object, order)				\
--	__atomic_load_n(&(object)->__val, order)
-+__extension__								\
-+({									\
-+	__auto_type __atomic_load_ptr = (object);				\
-+	__typeof__ (*__atomic_load_ptr) __atomic_load_tmp;			\
-+	__atomic_load (__atomic_load_ptr, &__atomic_load_tmp, (order));	\
-+	__atomic_load_tmp;							\
+ #define        atomic_exchange_explicit(object, desired, order)          \
+        __atomic_exchange_n(object, desired, order)
+ #define        atomic_fetch_add_explicit(object, operand, order)         \
+@@ -276,9 +290,21 @@
+ #define        atomic_fetch_xor_explicit(object, operand, order)         \
+        __atomic_fetch_xor(object, operand, order)
+ #define        atomic_load_explicit(object, order)                       \
+-       __atomic_load_n(object, order)
++__extension__                                                          \
++({                                                                     \
++       __auto_type __atomic_load_ptr = (object);                         \
++       __typeof__ (*__atomic_load_ptr) __atomic_load_tmp;                \
++       __atomic_load (__atomic_load_ptr, &__atomic_load_tmp, (order)); \
++       __atomic_load_tmp;                                                \
 +})
- #define	atomic_store_explicit(object, desired, order)			\
--	__atomic_store_n(&(object)->__val, desired, order)
-+__extension__								\
-+({									\
-+	__auto_type __atomic_store_ptr = (object);				\
-+	__typeof__ (*__atomic_store_ptr) __atomic_store_tmp = (desired);	\
-+	__atomic_store (__atomic_store_ptr, &__atomic_store_tmp, (order));	\
+ #define        atomic_store_explicit(object, desired, order)             \
+-       __atomic_store_n(object, desired, order)
++__extension__                                                          \
++({                                                                     \
++       __auto_type __atomic_store_ptr = (object);                        \
++       __typeof__ (*__atomic_store_ptr) __atomic_store_tmp = (desired);  \
++       __atomic_store (__atomic_store_ptr, &__atomic_store_tmp, (order));\
 +})
 +
  #else
- #define	__atomic_apply_stride(object, operand) \
- 	(((__typeof__((object)->__val))0) + (operand))
--- 
-2.20.1
-
+ #define        __atomic_apply_stride(object, operand) \
+        (((__typeof__((object)->__val))0) + (operand))


### PR DESCRIPTION
This is a work-in-progess of bumping the version to 4.0.0 related to #25 and is related to the Munich hackathon this weekend. I created the pull-request to perhaps serve as a point for future investigation and perhaps get some more points. ;)

I think fixing the patches is all that's needed to bump the version, I investigated the release notes and they didn't indicate major API changes, however this is untested.

## What was done

- update version and SHA256 sum in `Makefile.uk`
- some patches were updated

## What still needs to be done:

- testing
- clean up patch files, because they're kind of 'dirty' as of right now
- finish fixing patches, which are just re-applied from the previous patches and updated for the new headers of newlib.

## 0001 - 0006

I think I updated these correctly

## 0007 

I think this one has become redundant.

## 0008 + 0009 

On these ones I'm very unsure if I did it correctly

## 0010 - 0012

I could not get to these.