### PR TITLE
Introduce Library.uk

### DIFF
--- a/Library.uk
+++ b/Library.uk
@@ -1,0 +1,5 @@
+name        := "newlib"
+description := "A simple ANSI C library, math library, and collection of board support packages."
+homepage    := "http://sourceware.org/newlib/"
+license     := "BSD-3.0-Clause"
+version     := 2.5.0.20170922 sha256:16ccacbb9155b89a8333da057bfd2952d334795a38dfffcef6a4d83ae12e7275 http://sourceware.org/pub/newlib/newlib-2.5.0.20170922.tar.gz


### PR DESCRIPTION
This new file represents the first step towards proper versioning support of external microlibrary in Unikraft.  The file itself acts as mechanism for holding metadata-only values about the microlibrary.  This metadata is designed to be compatible with GNU Make whilst simultaneously being human-readable and readable by programs that are not GNU Make (e.g. tools such as KraftKit).

An important feature of this file is the inclusion of microlibrary versions. In a later step, once relevant integrations have been made to Unikrat's core build system and to relevant tools such as KraftKit, the user will be able to see and select from different versions of the microlibrary.

In this initial commit, the relevant metadata is absorbed from both Makefile.uk, Config.uk, but also includes new information such as SPDX License identifier. 

